### PR TITLE
20220718-수정하기기능 테스트-김명훈

### DIFF
--- a/app/src/main/java/panels/DiaryBoardPanel.java
+++ b/app/src/main/java/panels/DiaryBoardPanel.java
@@ -15,6 +15,8 @@ public class DiaryBoardPanel extends JPanel {
   private JFrame writingFrame;
   private JTextField titleTextField;
   private JTextArea writingTextArea;
+  private String title;
+  private String writingContent;
 
   private List<Writing> writings = new ArrayList<>();
 
@@ -56,8 +58,8 @@ public class DiaryBoardPanel extends JPanel {
 
         saveButton.addActionListener(new ActionListener() {
           public void actionPerformed(ActionEvent e) {
-            String title = titleTextField.getText();
-            String writingContent = writingTextArea.getText();
+            title = titleTextField.getText();
+            writingContent = writingTextArea.getText();
             //라이팅 생성
             Writing writing = new Writing(title,writingContent,"ORIGINAL");
             writings.add(writing);
@@ -101,6 +103,30 @@ public class DiaryBoardPanel extends JPanel {
                 writingFrame.setVisible(false);
                 writingListPanel = new WritingListPanel(writings,writingContentButton);
                 //패널 뉴 -> 버튼들 (패널1)-> 지운다 ,상태바꾼다 -> 셋비지블 보여라 (패널1)->
+                refresh();
+              });
+              modifyButton.addActionListener(event3 -> {
+                writing.modified();
+                titleTextField.setEditable(true);
+                writingTextArea.setEditable(true);
+                deleteModifyPanel.setLayout(new GridLayout(1,3));
+                JButton modifySaveButton = new JButton("저장하기");
+                deleteModifyPanel.add(modifySaveButton);
+                writingFrame.setVisible(true);
+
+                modifySaveButton.addActionListener(event4-> {
+                  title = titleTextField.getText();
+                  titleTextField.setText(title);
+                  writingContent = writingTextArea.getText();
+                  writingTextArea.setText(writingContent);
+                  titleTextField.setEditable(false);
+                  writingTextArea.setEditable(false);
+                  //라이팅 생성
+
+                  writingListPanel = new WritingListPanel(writings,writingContentButton);
+
+                  refresh();
+                });
 
               });
             });
@@ -109,7 +135,13 @@ public class DiaryBoardPanel extends JPanel {
       }
     });
   }
-
+  private void refresh() {
+    this.add(writingListPanel);
+    writingFrame.setDefaultCloseOperation(JFrame.DO_NOTHING_ON_CLOSE);
+    writingFrame.setVisible(false);
+    writingListPanel.setVisible((false));
+    writingListPanel.setVisible(true);
+  }
   private void refreshDisplay() {
     writingFrame.setDefaultCloseOperation(JFrame.DO_NOTHING_ON_CLOSE);
     writingFrame.setVisible(false);

--- a/app/src/main/java/panels/DiaryBoardPanel.java
+++ b/app/src/main/java/panels/DiaryBoardPanel.java
@@ -72,6 +72,7 @@ public class DiaryBoardPanel extends JPanel {
               writingFrame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
               writingFrame.setLocationRelativeTo(buttonPanel);
 
+              // TODO: kim babo
 
               JPanel framePanel = new JPanel();
               writingFrame.add(framePanel);


### PR DESCRIPTION
1. 1번시도   상태를 삭제하기로 만들고 글들을 새로 애딩 해주는 것을 생각함 -> 게시물이 삭제만 됨
텍스트필드나 에어리어도 새로운 스트링변수를 선언하고 만들어서 줫음

2. 수정하기 버튼 클릭시 글들의 상태가 수정으로 바뀌고 에디터블하게 하고 기존 텍스트 필드와 에어리어 변수를 그대로 가져와 (에디터블하게 했으면 당연히 그랬어야하는건데??) 저장하기 클릭하면 그곳의 텍스트를 겟텍스트 해준후 기존글의 속성에 다시 재할당, 그리고 기존의 텍스트필드와 에어리어에는 셋텍스트 그리고 라이팅리스트 패널을 다시 보여줌

3.시도해볼것
셋텍스트를 안해도 수정하기 기능이 돌아가는지